### PR TITLE
+ Tests & JaCoCo code coverage, minor fixes based on tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,8 +137,37 @@
                     <target>9</target>
                 </configuration>
             </plugin>
+
+            <!-- testing: code coverage -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.5</version>
+                <configuration>
+                    <excludes>
+                        <exclude>storytime/StorytimeApplication.class</exclude>
+                    </excludes>
+
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
 
     </build>
+
 
 </project>

--- a/src/main/java/storytime/child/StoryPreferencesRepository.java
+++ b/src/main/java/storytime/child/StoryPreferencesRepository.java
@@ -3,13 +3,9 @@ package storytime.child;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface StoryPreferencesRepository extends JpaRepository<StoryPreferences, Long> {
-    List<StoryPreferences> findById(long id);
-
-
-    List<StoryPreferences> findByOwnerId(long ownerId);
-
+    Optional<StoryPreferences> findByOwnerId(long ownerId);
 }

--- a/src/main/java/storytime/story/Story.java
+++ b/src/main/java/storytime/story/Story.java
@@ -52,4 +52,9 @@ public class Story {
     public void setContent(String content) {
         this.content = content;
     }
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName() + "{" + this.id + "}";
+    }
 }

--- a/src/main/java/storytime/story/StoryRestController.java
+++ b/src/main/java/storytime/story/StoryRestController.java
@@ -21,7 +21,7 @@ public class StoryRestController {
     }
 
     @GetMapping("/api/0.0.1/{id}")
-    public ResponseEntity<Story> getStoryByName(@PathVariable("id") long id) {
+    public ResponseEntity<Story> getStoryById(@PathVariable("id") long id) {
         Optional<Story> fromService = service.getStoryById(id);
 
         if (!fromService.isPresent()) {

--- a/src/main/java/storytime/story/StoryService.java
+++ b/src/main/java/storytime/story/StoryService.java
@@ -29,7 +29,17 @@ public class StoryService {
     }
 
     public void populateStories() {
+        // todo
 
+    }
+
+    public boolean persist(Story story) {
+        try {
+            repo.save(story);
+        } catch (Exception e) {
+            return false;
+        }
+        return true;
     }
 
 }

--- a/src/main/java/storytime/websites/UserSiteController.java
+++ b/src/main/java/storytime/websites/UserSiteController.java
@@ -21,6 +21,8 @@ import storytime.parent.ParentService;
 import javax.validation.Valid;
 import java.util.Optional;
 
+// todo move all services into rest-controllers which are called by this
+
 @Controller
 @EnableAutoConfiguration
 public class UserSiteController {
@@ -180,6 +182,7 @@ public class UserSiteController {
         return "user/child-prefs";
     }
 
+    // todo fix update case
     @PostMapping("/parent/{pid}/child/{cid}/prefs")
     public String parent__pid__child__cid__prefs(Model model,
                                                  @PathVariable("pid") long parentId,
@@ -192,6 +195,8 @@ public class UserSiteController {
         // story prefs owner is child
         childService.getChildById(childId).ifPresent(c -> {
             log.info("child found: {}", c);
+
+            // see if a story-prefs already exists
             storyPreferences.setOwner(c);
         });
 
@@ -208,4 +213,5 @@ public class UserSiteController {
 
         return parent__id(model, parentId);
     }
+
 }

--- a/src/test/java/storytime/StorytimeStoriesApplicationTests.java
+++ b/src/test/java/storytime/StorytimeStoriesApplicationTests.java
@@ -1,4 +1,4 @@
-package storytime.story;
+package storytime;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/src/test/java/storytime/child/ChildServiceTest.java
+++ b/src/test/java/storytime/child/ChildServiceTest.java
@@ -1,0 +1,81 @@
+package storytime.child;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.context.SpringBootTest;
+import storytime.parent.Parent;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.BDDMockito.given;
+
+@SpringBootTest
+class ChildServiceTest {
+    // predefined test objects
+    private static final Parent parent = new Parent(0, "Parent",
+            "passphrase", Set.of());
+
+    private static final Child validChild = new Child(1, "ChildA", parent,
+            new StoryPreferences(), null, null);
+
+    private static final Child emptyChild = new Child();
+
+    // test subject
+    private ChildService subject;
+
+    @Mock
+    private ChildRepository childRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        subject = new ChildService(childRepository);
+
+        // mock child-repo
+        given(childRepository.findById(1L)).willReturn(Optional.of(validChild));
+        given(childRepository.findById(-1L)).willReturn(Optional.empty());
+
+        given(childRepository.save(validChild)).willReturn(validChild);
+        given(childRepository.save(emptyChild)).willThrow(new IllegalArgumentException());
+
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    @Test
+    void persist__valid_child() {
+        assertTrue(subject.persist(validChild));
+    }
+
+    @Test
+    void persist__invalid_child() {
+        assertFalse(subject.persist(emptyChild));
+    }
+
+    @Test
+    void getChildById__found() {
+        Optional<Child> actual = subject.getChildById(1L);
+        Optional<Child> expect = Optional.of(validChild);
+
+        assertThat(actual).isEqualTo(expect);
+    }
+
+    @Test
+    void getChildById__not_found() {
+        Optional<Child> actual = subject.getChildById(-1L);
+        Optional<Child> expect = Optional.empty();
+
+        assertThat(actual).isEqualTo(expect);
+    }
+
+}

--- a/src/test/java/storytime/child/ChildTest.java
+++ b/src/test/java/storytime/child/ChildTest.java
@@ -1,0 +1,62 @@
+package storytime.child;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import storytime.parent.Parent;
+import storytime.story.Story;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// note: these tests are just for coverage,
+// since this is a Model entity with no logic
+@SpringBootTest
+class ChildTest {
+
+    // test subject
+    private Child subject;
+
+    @BeforeEach
+    void setUp() {
+        subject = new Child();
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    @Test
+    void test_entity() {
+        long id = 1L;
+        subject.setId(id);
+        assertThat(subject.getId()).isEqualTo(id);
+
+        String name = "Child";
+        subject.setName(name);
+        assertThat(subject.getName()).isEqualTo(name);
+
+        Parent parent = new Parent();
+        subject.setParent(parent);
+        assertThat(subject.getParent()).isEqualTo(parent);
+
+        StoryPreferences storyPreferences = new StoryPreferences();
+        subject.setStoryPreferences(storyPreferences);
+        assertThat(subject.getStoryPreferences()).isEqualTo(storyPreferences);
+
+        Set<Story> stories = Set.of(new Story(), new Story());
+        subject.setFavoriteStories(stories);
+        assertThat(subject.getFavoriteStories()).isEqualTo(stories);
+
+        subject.setDislikedStories(stories);
+        assertThat(subject.getDislikedStories()).isEqualTo(stories);
+
+        assertThat(subject.toString()).isEqualTo("Child{1}");
+
+        assertThat(subject).isEqualToComparingFieldByField(
+                new Child(id, name, parent, storyPreferences, stories, stories)
+        );
+    }
+}

--- a/src/test/java/storytime/child/StoryPreferencesServiceTest.java
+++ b/src/test/java/storytime/child/StoryPreferencesServiceTest.java
@@ -1,0 +1,105 @@
+package storytime.child;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.context.SpringBootTest;
+import storytime.parent.Parent;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.BDDMockito.given;
+
+@SpringBootTest
+class StoryPreferencesServiceTest {
+    // predefined test objects
+    private static final Parent parent = new Parent(0, "Parent",
+            "passphrase", Set.of());
+    private static final Child child = new Child(1, "Child", parent,
+            new StoryPreferences(), null, null);
+
+
+    private static final StoryPreferences validStoryPreferences =
+            new StoryPreferences(0, child, "setting", "protagonist", "mom", "dad", "bro", "sis", "pet", "species");
+    private static final StoryPreferences emptyStoryPreferences =
+            new StoryPreferences();
+    // test subject
+    private StoryPreferencesService subject;
+    @Mock
+    private StoryPreferencesRepository storyPreferencesRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        subject = new StoryPreferencesService(storyPreferencesRepository);
+
+        // mock story-prefs-repo
+        given(storyPreferencesRepository.findById(1L)).willReturn(Optional.of(validStoryPreferences));
+        given(storyPreferencesRepository.findById(-1L)).willReturn(Optional.empty());
+
+        given(storyPreferencesRepository.findByOwnerId(child.getId())).willReturn(Optional.of(validStoryPreferences));
+        given(storyPreferencesRepository.findByOwnerId(-1L)).willReturn(Optional.empty());
+
+        given(storyPreferencesRepository.save(validStoryPreferences)).willReturn(validStoryPreferences);
+        given(storyPreferencesRepository.save(emptyStoryPreferences)).willThrow(new IllegalArgumentException());
+
+
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    @Test
+    void persist__valid_story_prefs() {
+        assertTrue(subject.persist(validStoryPreferences));
+    }
+
+    @Test
+    void persist__invalid_story_prefs() {
+        assertFalse(subject.persist(emptyStoryPreferences));
+    }
+
+
+    @Test
+    void getStoryPreferencesById__found() {
+        Optional<StoryPreferences> actual = subject.getStoryPreferencesById(1L);
+        Optional<StoryPreferences> expect = Optional.of(validStoryPreferences);
+
+        assertThat(actual).isEqualTo(expect);
+    }
+
+    @Test
+    void getStoryPreferencesById__not_found() {
+        Optional<StoryPreferences> actual = subject.getStoryPreferencesById(-1L);
+        Optional<StoryPreferences> expect = Optional.empty();
+
+        assertThat(actual).isEqualTo(expect);
+    }
+
+    @Test
+    void getStoryPreferencesByOwner__found() {
+        Optional<StoryPreferences> actual = subject.getStoryPreferencesByOwner(child);
+        Optional<StoryPreferences> expect = Optional.of(validStoryPreferences);
+
+        assertThat(actual).isEqualTo(expect);
+    }
+
+    @Test
+    void getStoryPreferencesByOwner__not_found() {
+        Child nonexistantChild = new Child();
+        nonexistantChild.setId(-1L);
+        Optional<StoryPreferences> actual = subject.getStoryPreferencesByOwner(nonexistantChild);
+        Optional<StoryPreferences> expect = Optional.empty();
+
+        assertThat(actual).isEqualTo(expect);
+
+    }
+}

--- a/src/test/java/storytime/child/StoryPreferencesTest.java
+++ b/src/test/java/storytime/child/StoryPreferencesTest.java
@@ -1,0 +1,74 @@
+package storytime.child;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// note: these tests are just for coverage,
+// since this is a Model entity with no logic
+@SpringBootTest
+class StoryPreferencesTest {
+
+    // test subject
+    private StoryPreferences subject;
+
+    @BeforeEach
+    void setUp() {
+        subject = new StoryPreferences();
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    @Test
+    void test_entity() {
+        long id = 1L;
+        subject.setId(id);
+        assertThat(subject.getId()).isEqualTo(id);
+
+        Child owner = new Child();
+        subject.setOwner(owner);
+        assertThat(subject.getOwner()).isEqualTo(owner);
+
+        String setting = "setting";
+        subject.setSetting(setting);
+        assertThat(subject.getSetting()).isEqualTo(setting);
+
+        String protagonist = "protagonist";
+        subject.setProtagonistCharacterName(protagonist);
+        assertThat(subject.getProtagonistCharacterName()).isEqualTo(protagonist);
+
+        String mom = "mom";
+        subject.setMomCharacterName(mom);
+        assertThat(subject.getMomCharacterName()).isEqualTo(mom);
+
+        String dad = "dad";
+        subject.setDadCharacterName(dad);
+        assertThat(subject.getDadCharacterName()).isEqualTo(dad);
+
+        String bro = "bro";
+        subject.setBrotherCharacterName(bro);
+        assertThat(subject.getBrotherCharacterName()).isEqualTo(bro);
+
+        String sis = "sis";
+        subject.setSisterCharacterName(sis);
+        assertThat(subject.getSisterCharacterName()).isEqualTo(sis);
+
+        String pet = "pet";
+        subject.setPetCharacterName(pet);
+        assertThat(subject.getPetCharacterName()).isEqualTo(pet);
+
+        String species = "species";
+        subject.setPetCharacterSpecies(species);
+        assertThat(subject.getPetCharacterSpecies()).isEqualTo(species);
+
+        assertThat(subject.toString()).isEqualTo("StoryPreferences{1}");
+        assertThat(subject).isEqualToComparingFieldByField(
+                new StoryPreferences(id, owner, setting, protagonist,
+                        mom, dad, bro, sis, pet, species));
+    }
+}

--- a/src/test/java/storytime/parent/ParentServiceTest.java
+++ b/src/test/java/storytime/parent/ParentServiceTest.java
@@ -1,0 +1,114 @@
+package storytime.parent;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.BDDMockito.given;
+
+@SpringBootTest
+class ParentServiceTest {
+
+    // predefined test objects
+    private static final Parent validParent = new Parent(0, "Parent",
+            "passphrase", new HashSet<>());
+    private static final Parent dupeNameParentA = new Parent(1, "Dupe Parent",
+            "passphrase", new HashSet<>());
+    private static final Parent dupeNameParentB = new Parent(2, "Dupe Parent",
+            "passphrase", new HashSet<>());
+
+    private static final Parent emptyParent = new Parent();
+
+    // test subject
+    private ParentService subject;
+
+    @Mock
+    private ParentRepository parentRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        subject = new ParentService(parentRepository);
+
+        // mock parent-repo
+        given(parentRepository.findById(0L)).willReturn(Optional.of(validParent));
+        given(parentRepository.findById(-1L)).willReturn(Optional.empty());
+
+        given(parentRepository.findByUsername("Parent")).willReturn(List.of(validParent));
+
+        // note, username is enforced to be unique in entity, this is just a safeguard check
+        given(parentRepository.findByUsername("Dupe Parent")).willReturn(List.of(dupeNameParentA, dupeNameParentB));
+        given(parentRepository.findByUsername("NOBODY")).willReturn(List.of());
+
+        given(parentRepository.save(validParent)).willReturn(validParent);
+        given(parentRepository.save(emptyParent)).willThrow(new IllegalArgumentException());
+    }
+
+    @AfterEach
+    void tearDown() {
+
+    }
+
+    @Test
+    void persist__valid_parent() {
+        assertTrue(subject.persist(validParent));
+    }
+
+    @Test
+    void persist__invalid_parent() {
+        assertFalse(subject.persist(emptyParent));
+    }
+
+    @Test
+    void getParentById__found() {
+        Optional<Parent> actual = subject.getParentById(0L);
+        Optional<Parent> expect = Optional.of(validParent);
+
+        assertThat(actual).isEqualTo(expect);
+    }
+
+    @Test
+    void getParentById__not_found() {
+        Optional<Parent> actual = subject.getParentById(-1L);
+        Optional<Parent> expect = Optional.empty();
+
+        assertThat(actual).isEqualTo(expect);
+    }
+
+    @Test
+    void getParentByUsername__found_one() {
+        Optional<Parent> actual = subject.getParentByUsername("Parent");
+        Optional<Parent> expect = Optional.of(validParent);
+
+        assertThat(actual).isEqualTo(expect);
+    }
+
+    @Test
+    void getParentByUsername__found_none() {
+        Optional<Parent> actual = subject.getParentByUsername("NOBODY");
+        Optional<Parent> expect = Optional.empty();
+
+        assertThat(actual).isEqualTo(expect);
+    }
+
+    @Test
+    void getParentByUsername__found_two() {
+        Optional<Parent> actual = subject.getParentByUsername("Dupe Parent");
+        Optional<Parent> expect = Optional.of(dupeNameParentA);
+
+        assertThat(actual).isEqualTo(expect);
+    }
+
+
+}

--- a/src/test/java/storytime/parent/ParentTest.java
+++ b/src/test/java/storytime/parent/ParentTest.java
@@ -1,0 +1,48 @@
+package storytime.parent;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import storytime.child.Child;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+// note: these tests are just for coverage,
+// since this is a Model entity with no logic
+
+@SpringBootTest
+class ParentTest {
+
+    // test subject
+    private Parent subject;
+
+    @BeforeEach
+    void setUp() {
+        subject = new Parent();
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    @Test
+    void test_entity() {
+
+        subject.setId(1L);
+        assertThat(subject.getId()).isEqualTo(1L);
+
+        subject.setUsername("Parent");
+        assertThat(subject.getUsername()).isEqualTo("Parent");
+
+        subject.setPassphrase("passphrase");
+        assertThat(subject.getPassphrase()).isEqualTo("passphrase");
+
+        Set<Child> children = Set.of(new Child(), new Child());
+        subject.setChildren(children);
+        assertThat(subject.getChildren()).isEqualTo(children);
+
+        assertThat(subject.toString()).isEqualTo("Parent{1}");
+    }
+}

--- a/src/test/java/storytime/story/StoryRestControllerMVCTest.java
+++ b/src/test/java/storytime/story/StoryRestControllerMVCTest.java
@@ -1,0 +1,96 @@
+package storytime.story;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.json.JacksonTester;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+@WebMvcTest(StoryRestController.class)
+class StoryRestControllerMVCTest {
+
+    // predefined test objects
+    private static final Story story =
+            new Story(1L, "title", "content");
+
+    @MockBean
+    private StoryService storyService;
+
+    @Autowired
+    private MockMvc mvc;
+
+    // subject (for api testing)
+    private JacksonTester<Story> subject;
+
+    @BeforeEach
+    void setUp() {
+        JacksonTester.initFields(this, new ObjectMapper());
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    @Test
+    void api__getStoryById__valid() throws Exception {
+        // input
+        Story attempt = new Story();
+        long id = 1L;
+        attempt.setId(id);
+
+        // expected
+        given(storyService.getStoryById(attempt.getId()))
+                .willReturn(Optional.of(story));
+
+        // when
+        MockHttpServletResponse response = mvc.perform(
+                get("/api/0.0.1/" + id)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(subject.write(attempt).getJson())
+        ).andReturn().getResponse();
+
+        // then
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.getContentAsString())
+                .isEqualTo(subject.write(story).getJson());
+
+    }
+
+    @Test
+    void api__getStoryById__invalid() throws Exception {
+        // input
+        Story attempt = new Story();
+        long id = -1L;
+        attempt.setId(id);
+
+        // expected
+        given(storyService.getStoryById(attempt.getId()))
+                .willReturn(Optional.empty());
+
+        // when
+        MockHttpServletResponse response = mvc.perform(
+                get("/api/0.0.1/" + id)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(subject.write(attempt).getJson())
+        ).andReturn().getResponse();
+
+        // then
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+        assertThat(response.getContentAsString())
+                .isEqualTo("");
+
+    }
+}

--- a/src/test/java/storytime/story/StoryRestControllerTest.java
+++ b/src/test/java/storytime/story/StoryRestControllerTest.java
@@ -1,0 +1,64 @@
+package storytime.story;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@SpringBootTest
+class StoryRestControllerTest {
+
+    // predefined test objects
+    private static final Story story =
+            new Story(1L, "title", "content");
+
+
+    // predefined responses
+    private static final ResponseEntity<Story> responseOK =
+            new ResponseEntity<>(story, HttpStatus.OK);
+    private static final ResponseEntity<Story> responseNF =
+            new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
+
+    // test subject
+    private StoryRestController subject;
+
+    @Mock
+    private StoryService storyService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        subject = new StoryRestController(storyService);
+
+        // mock story-service
+        given(storyService.getStoryById(1L)).willReturn(Optional.of(story));
+        given(storyService.getStoryById(-1L)).willReturn(Optional.empty());
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    @Test
+    void getStoryById__valid() {
+        ResponseEntity<Story> actual = subject.getStoryById(story.getId());
+        assertThat(actual).isEqualTo(responseOK);
+    }
+
+    @Test
+    void getStoryById__invalid() {
+        ResponseEntity<Story> actual = subject.getStoryById(-1L);
+        assertThat(actual).isEqualTo(responseNF);
+
+    }
+}

--- a/src/test/java/storytime/story/StoryServiceTest.java
+++ b/src/test/java/storytime/story/StoryServiceTest.java
@@ -1,0 +1,79 @@
+package storytime.story;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.BDDMockito.given;
+
+class StoryServiceTest {
+
+    // predefined test objects
+    private static final Story validStory =
+            new Story(1L, "Story", "content");
+    private static final Story emptyStory = new Story();
+
+    // test subject
+    private StoryService subject;
+
+    @Mock
+    private StoryRepository storyRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+        subject = new StoryService(storyRepository);
+
+        // mock story-repo
+        given(storyRepository.findById(1L)).willReturn(Optional.of(validStory));
+        given(storyRepository.findById(-1L)).willReturn(Optional.empty());
+
+        given(storyRepository.save(validStory)).willReturn(validStory);
+        given(storyRepository.save(emptyStory)).willThrow(new IllegalArgumentException());
+
+
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    @Test
+    void persist__valid_story() {
+        assertTrue(subject.persist(validStory));
+    }
+
+    @Test
+    void persist__invalid_story() {
+        assertFalse(subject.persist(emptyStory));
+    }
+
+    @Test
+    void getChildById__found() {
+        Optional<Story> actual = subject.getStoryById(1L);
+        Optional<Story> expect = Optional.of(validStory);
+
+        assertThat(actual).isEqualTo(expect);
+    }
+
+    @Test
+    void getChildById__not_found() {
+        Optional<Story> actual = subject.getStoryById(-1L);
+        Optional<Story> expect = Optional.empty();
+
+        assertThat(actual).isEqualTo(expect);
+    }
+
+    @Test
+    void populateStories__valid() {
+        // todo
+        subject.populateStories();
+    }
+}

--- a/src/test/java/storytime/story/StoryTest.java
+++ b/src/test/java/storytime/story/StoryTest.java
@@ -1,0 +1,49 @@
+package storytime.story;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// note: these tests are just for coverage,
+// since this is a Model entity with no logic
+@SpringBootTest
+class StoryTest {
+
+    // test subject
+    private Story subject;
+
+    @BeforeEach
+    void setUp() {
+        subject = new Story();
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    @Test
+    void test_entity() {
+        long id = 1L;
+        subject.setId(id);
+        assertThat(subject.getId()).isEqualTo(id);
+
+        String title = "title";
+        subject.setTitle(title);
+        assertThat(subject.getTitle()).isEqualTo(title);
+
+        String content = "content";
+        subject.setContent(content);
+        assertThat(subject.getContent()).isEqualTo(content);
+
+        assertThat(subject.toString()).isEqualTo("Story{1}");
+
+        assertThat(subject).isEqualToComparingFieldByField(
+                new Story(id, title, content)
+        );
+
+
+    }
+}


### PR DESCRIPTION
Updated pom.xml for JaCoCo
StoryPreferencesRepository
    findOwnerById now returns optional since one or zero results are expected
    removed findById since default impl already provided
Story added missing toString
StoryRestController getStoryByName renamed to getStoryById (which is what it was doing)
StoryService added missing persist method
Added tests for ChildService, Child, StoryPreferences, StoryPreferencesService, Parent, ParentService, StoryRestController (including MVC test)